### PR TITLE
predict can take newdata

### DIFF
--- a/R/IndividualData.R
+++ b/R/IndividualData.R
@@ -115,6 +115,7 @@ IndividualData <- function(data,
                            degrees_of_freedom_cp=4){
 
 
+
   # Work on a copy of the input data
   tmp <- as.data.frame(data)
 
@@ -235,7 +236,8 @@ IndividualData <- function(data,
               calendar_period_extrapolation=calendar_period_extrapolation,
               years=years,
               accident_period=accident_period,
-              input_time_granularity=input_time_granularity)
+              input_time_granularity=input_time_granularity,
+              output_time_granularity=output_time_granularity)
 
   # Return the correct output
   class(out) <- "IndividualData"

--- a/R/predictReSurvFit.R
+++ b/R/predictReSurvFit.R
@@ -2,7 +2,8 @@
 #'
 #' This function predicts the results from the ReSurv fits.
 #'
-#' @param object "ResurvFit" object specifying start time, end time and status.
+#' @param object \code{ResurvFit} object specifying start time, end time and status.
+#' @param newdata \code{IndividualData} object that contains
 #' @param grouping_method \code{character}, use probability or exposure approach to group from input to output development factors. Choice between:
 #' \itemize{
 #' \item{\code{"exposure"}}
@@ -16,34 +17,48 @@
 #' @export
 #' @method predict ReSurvFit
 predict.ReSurvFit <- function(object,
+                              newdata=NULL,
                               grouping_method = "exposure",
                               check_value = 1.85){
 
+
+  if(!is.null(newdata)){
+    pkg.env$check.newdata(newdata=newdata,
+                          pastdata=object$IndividualData)
+    idata <- newdata
+  }else{
+
+    idata <- object$IndividualData
+
+    }
+
+
+
   hazard_frame_grouped <- pkg.env$covariate_mapping(
     hazard_frame = object$hazard_frame,
-    categorical_features = object$IndividualData$categorical_features,
-    continuous_features = object$IndividualData$continuous_features,
-    conversion_factor = object$IndividualData$conversion_factor,
-    calendar_period_extrapolation = object$IndividualData$calendar_period_extrapolation
+    categorical_features = idata$categorical_features,
+    continuous_features = idata$continuous_features,
+    conversion_factor = idata$conversion_factor,
+    calendar_period_extrapolation = idata$calendar_period_extrapolation
   )
 
-  missing.obsevations <- pkg.env$fill_data_frame(data=object$IndividualData$full.data,
-                                                 continuous_features=object$IndividualData$continuous_features,
-                                                 categorical_features=object$IndividualData$categorical_features,
-                                                 years=object$IndividualData$years,
-                                                 input_time_granularity=object$IndividualData$input_time_granularity,
-                                                 conversion_factor=object$IndividualData$conversion_factor)
+  missing.obsevations <- pkg.env$fill_data_frame(data=idata$full.data,
+                                                 continuous_features=idata$continuous_features,
+                                                 categorical_features=idata$categorical_features,
+                                                 years=idata$years,
+                                                 input_time_granularity=idata$input_time_granularity,
+                                                 conversion_factor=idata$conversion_factor)
 
 
   latest_observed <- pkg.env$latest_observed_values_i(
-    data_reserve= bind_rows(object$IndividualData$training.data, missing.obsevations),
+    data_reserve= bind_rows(idata$training.data, missing.obsevations),
     groups = hazard_frame_grouped$groups,
-    categorical_features = object$IndividualData$categorical_features,
-    continuous_features = object$IndividualData$continuous_features,
-    calendar_period_extrapolation = object$IndividualData$calendar_period_extrapolation
+    categorical_features = idata$categorical_features,
+    continuous_features = idata$continuous_features,
+    calendar_period_extrapolation = idata$calendar_period_extrapolation
   )
 
-  max_DP <- max(bind_rows(object$IndividualData$training.data, missing.obsevations)$DP_rev_o)
+  max_DP <- max(bind_rows(idata$training.data, missing.obsevations)$DP_rev_o)
 
 
   expected_i <- pkg.env$predict_i(
@@ -61,21 +76,21 @@ predict.ReSurvFit <- function(object,
   hazard_frame_input <- pkg.env$input_hazard_frame(
     hazard_frame = hazard_frame_grouped$hazard_group,
     expected_i = expected_i ,
-    categorical_features = object$IndividualData$categorical_features,
-    continuous_features = object$IndividualData$continuous_features,
+    categorical_features = idata$categorical_features,
+    continuous_features = idata$continuous_features,
     df_i = df_i,
     groups = hazard_frame_grouped$groups)
 
 
-  if(object$IndividualData$conversion_factor != 1){
+  if(idata$conversion_factor != 1){
 
-    development_periods <- distinct(select(data.frame(object$IndividualData$training), AP_i, AP_o))
+    development_periods <- distinct(select(data.frame(idata$training), AP_i, AP_o))
 
     # Calculate the minimum and maximum development periods for each row in development_periods for each DP_rev_o
     dp_ranges <- t(lapply(1:max_DP, function(DP_rev_o) {
       cbind(DP_rev_o, development_periods,
-            min_dp = with(development_periods, AP_i+1/(object$IndividualData$conversion_factor)*(DP_rev_o-AP_o)),
-            max_dp = with(development_periods, AP_i-1+1/(object$IndividualData$conversion_factor)*(DP_rev_o-AP_o+1)))
+            min_dp = with(development_periods, AP_i+1/(idata$conversion_factor)*(DP_rev_o-AP_o)),
+            max_dp = with(development_periods, AP_i-1+1/(idata$conversion_factor)*(DP_rev_o-AP_o+1)))
     }
     ))
 
@@ -97,7 +112,7 @@ predict.ReSurvFit <- function(object,
         groups = hazard_frame_grouped$groups,
         observed_pr_dp = latest_observed$observed_pr_dp,
         latest_cumulative = latest_observed$latest_cumulative,
-        conversion_factor = object$IndividualData$conversion_factor,
+        conversion_factor = idata$conversion_factor,
         grouping_method = "probability",
         min_DP_rev_i = min(hazard_frame_grouped$hazard_group$DP_rev_i)
       )
@@ -120,9 +135,9 @@ predict.ReSurvFit <- function(object,
         df_o=df_o,
         latest_observed_i = latest_observed$observed_pr_dp,
         groups = hazard_frame_grouped$groups,
-        categorical_features=object$IndividualData$categorical_features,
-        continuous_features = object$IndividualData$continuous_features,
-        conversion_factor = object$IndividualData$conversion_factor,
+        categorical_features=idata$categorical_features,
+        continuous_features = idata$continuous_features,
+        conversion_factor = idata$conversion_factor,
         check_value = check_value
       )
 
@@ -141,8 +156,8 @@ predict.ReSurvFit <- function(object,
       hazard_frame_input <- pkg.env$input_hazard_frame(
         hazard_frame = hazard_frame_grouped$hazard_group,
         expected_i = expected_i ,
-        categorical_features = object$IndividualData$categorical_features,
-        continuous_features = object$IndividualData$continuous_features,
+        categorical_features = idata$categorical_features,
+        continuous_features = idata$continuous_features,
         df_i = df_i,
         groups = hazard_frame_grouped$groups,
         adjusted=T)
@@ -153,7 +168,7 @@ predict.ReSurvFit <- function(object,
 
     expected_o <-pkg.env$predict_o(expected_i = expected_i,
                                    groups = hazard_frame_grouped$groups,
-                                   conversion_factor = object$IndividualData$conversion_factor)
+                                   conversion_factor = idata$conversion_factor)
 
 
 
@@ -164,7 +179,7 @@ predict.ReSurvFit <- function(object,
       groups = hazard_frame_grouped$groups,
       observed_pr_dp = latest_observed$observed_pr_dp,
       latest_cumulative = latest_observed$latest_cumulative,
-      conversion_factor = object$IndividualData$conversion_factor,
+      conversion_factor = idata$conversion_factor,
       grouping_method = grouping_method,
       min_DP_rev_i = min(hazard_frame_grouped$hazard_group$DP_rev_i)
     )
@@ -187,8 +202,8 @@ predict.ReSurvFit <- function(object,
     hazard_frame_output <- pkg.env$output_hazard_frame(
       hazard_frame_input=hazard_frame_input,
       expected_o=expected_o,
-      categorical_features=object$IndividualData$categorical_features,
-      continuous_features=object$IndividualData$continuous_features,
+      categorical_features=idata$categorical_features,
+      continuous_features=idata$continuous_features,
       df_o=df_o,
       groups = hazard_frame_grouped$groups
     )

--- a/man/pkg.env.Rd
+++ b/man/pkg.env.Rd
@@ -5,7 +5,7 @@
 \alias{pkg.env}
 \title{Helper functions}
 \format{
-An object of class \code{environment} of length 55.
+An object of class \code{environment} of length 56.
 }
 \usage{
 pkg.env

--- a/man/predict.ReSurvFit.Rd
+++ b/man/predict.ReSurvFit.Rd
@@ -4,10 +4,17 @@
 \alias{predict.ReSurvFit}
 \title{Predict IBNR frequency}
 \usage{
-\method{predict}{ReSurvFit}(object, grouping_method = "exposure", check_value = 1.85)
+\method{predict}{ReSurvFit}(
+  object,
+  newdata = NULL,
+  grouping_method = "exposure",
+  check_value = 1.85
+)
 }
 \arguments{
-\item{object}{"ResurvFit" object specifying start time, end time and status.}
+\item{object}{\code{ResurvFit} object specifying start time, end time and status.}
+
+\item{newdata}{\code{IndividualData} object that contains}
 
 \item{grouping_method}{\code{character}, use probability or exposure approach to group from input to output development factors. Choice between:
 \itemize{

--- a/vignettes/deepsurv.Rmd
+++ b/vignettes/deepsurv.Rmd
@@ -55,9 +55,36 @@ resurv.fit.cox <- ReSurv(individual_data,
 
 ```
 
+
 ```{r}
 
 ooslkh(resurv.fit.cox)
+
+```
+
+```{r}
+
+resurv.cox.predictions <- predict(resurv.fit.cox)
+
+```
+
+```{r}
+
+individual_data2 <- IndividualData(input_data,
+                                  id=NULL,
+                                  continuous_features="AP",
+                                  categorical_features="claim_type",
+                                  accident_period="AP",
+                                  calendar_period="RP",
+                                  input_time_granularity = "days",
+                                  output_time_granularity = "years",
+                                  years=4,
+                                  continuous_features_spline=NULL,
+                                  calendar_period_extrapolation=F)
+
+
+resurv.cox.predictions <- predict(resurv.fit.cox,
+                                  newdata=individual_data2)
 
 ```
 


### PR DESCRIPTION
Comparing pastdata and newdata:

- Features must be the same.
- Input granularity must be the same.
- Input granularity and output granularity must be convertible.
- It is NOT necessary to provide a newdata argument in case you want to predict on the old data.